### PR TITLE
Fixed validation for client and duplex streaming.

### DIFF
--- a/src/Calzolari.Grpc.AspNetCore.Validation.SampleRpc/Protos/greet.proto
+++ b/src/Calzolari.Grpc.AspNetCore.Validation.SampleRpc/Protos/greet.proto
@@ -9,6 +9,8 @@ service Greeter {
   // Sends a greeting
   rpc SayHello (HelloRequest) returns (HelloReply);
   rpc SayHelloServerStreaming (HelloRequest) returns (stream HelloReply);
+  rpc SayHelloClientStreaming (stream HelloRequest) returns (HelloReply);
+  rpc SayHelloDuplexStreaming (stream HelloRequest) returns (stream HelloReply);
 }
 
 // The request message containing the user's name.

--- a/src/Calzolari.Grpc.AspNetCore.Validation.SampleRpc/Services/GreeterService.cs
+++ b/src/Calzolari.Grpc.AspNetCore.Validation.SampleRpc/Services/GreeterService.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Grpc.Core;
 using Microsoft.Extensions.Logging;
@@ -27,6 +28,26 @@ namespace Calzolari.Grpc.AspNetCore.Validation.SampleRpc
             {
                 Message = "Hello " + request.Name
             });
+        }
+
+        public override async Task<HelloReply> SayHelloClientStreaming(IAsyncStreamReader<HelloRequest> requestStream, ServerCallContext context)
+        {
+            var names = new List<string>();
+            await foreach (var request in requestStream.ReadAllAsync())
+            {
+                names.Add(request.Name);
+            }
+
+            return new HelloReply {Message = "Hello " + string.Join(", ", names)};
+        }
+
+        public override async Task SayHelloDuplexStreaming(IAsyncStreamReader<HelloRequest> requestStream, IServerStreamWriter<HelloReply> responseStream,
+            ServerCallContext context)
+        {
+            await foreach (var request in requestStream.ReadAllAsync())
+            {
+                await responseStream.WriteAsync(new HelloReply {Message = "Hello " + request.Name});
+            }
         }
     }
 }

--- a/src/Calzolari.Grpc.AspNetCore.Validation/Internal/ValidatingAsyncStreamReader.cs
+++ b/src/Calzolari.Grpc.AspNetCore.Validation/Internal/ValidatingAsyncStreamReader.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Grpc.Core;
+
+namespace Calzolari.Grpc.AspNetCore.Validation.Internal
+{
+    internal class ValidatingAsyncStreamReader<TRequest> : IAsyncStreamReader<TRequest>
+    {
+        private readonly IAsyncStreamReader<TRequest> _innerReader;
+        private readonly Func<TRequest, Task> _validator;
+
+        public ValidatingAsyncStreamReader(IAsyncStreamReader<TRequest> innerReader, Func<TRequest, Task> validator)
+        {
+            _innerReader = innerReader;
+            _validator = validator;
+        }
+        
+        public async Task<bool> MoveNext(CancellationToken cancellationToken)
+        {
+            var success = await _innerReader.MoveNext(cancellationToken).ConfigureAwait(false);
+            if (success)
+            {
+                await _validator.Invoke(Current).ConfigureAwait(false);
+            }
+
+            return success;
+        }
+
+        public TRequest Current => _innerReader.Current;
+    }
+}

--- a/src/Calzolari.Grpc.AspNetCore.Validation/Internal/ValidationInterceptor.cs
+++ b/src/Calzolari.Grpc.AspNetCore.Validation/Internal/ValidationInterceptor.cs
@@ -37,12 +37,8 @@ namespace Calzolari.Grpc.AspNetCore.Validation.Internal
                                                                                      ServerCallContext context, 
                                                                                      ClientStreamingServerMethod<TRequest, TResponse> continuation)
         {
-            await foreach (var message in requestStream.ReadAllAsync())
-            {
-                await ValidateRequest(message);
-            }
-
-            return await continuation(requestStream, context);
+            var validatingRequestStream = new ValidatingAsyncStreamReader<TRequest>(requestStream, request => ValidateRequest(request));
+            return await continuation(validatingRequestStream, context);
         }
 
         public override async Task DuplexStreamingServerHandler<TRequest, TResponse>(IAsyncStreamReader<TRequest> requestStream, 
@@ -50,12 +46,8 @@ namespace Calzolari.Grpc.AspNetCore.Validation.Internal
                                                                                      ServerCallContext context, 
                                                                                      DuplexStreamingServerMethod<TRequest, TResponse> continuation)
         {
-            await foreach (var message in requestStream.ReadAllAsync())
-            {
-                await ValidateRequest(message);
-            }
-
-            await continuation(requestStream, responseStream, context);
+            var validatingRequestStream = new ValidatingAsyncStreamReader<TRequest>(requestStream, request => ValidateRequest(request));
+            await continuation(validatingRequestStream, responseStream, context);
         }
 
         private async Task ValidateRequest<TRequest>(TRequest request) where TRequest : class


### PR DESCRIPTION
Unfortunately, the current implementation of validation is incorrect: the client stream is being read to the end in the interceptor in order to perform validation, thus the continuation receives the completed stream that cannot be read anymore. So client and duplex streaming is completely broken with version 5.1.0 of this library.

Instead, I suggest using ValidatingAsyncStreamReader<TRequest>. It is a decorator over the original IAsyncStreamReader<TRequest>, which perform validation for each item being read when MoveNext() is called.