### PR TITLE
Implement the ability to manually add errors in response trailers

### DIFF
--- a/src/Calzolari.Grpc.AspNetCore.Validation.SampleRpc/Calzolari.Grpc.AspNetCore.Validation.SampleRpc.csproj
+++ b/src/Calzolari.Grpc.AspNetCore.Validation.SampleRpc/Calzolari.Grpc.AspNetCore.Validation.SampleRpc.csproj
@@ -5,6 +5,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <Protobuf Include="Protos\duplicate_check.proto" GrpcServices="Both" />
         <Protobuf Include="Protos\greet.proto" GrpcServices="Both" />
     </ItemGroup>
 

--- a/src/Calzolari.Grpc.AspNetCore.Validation.SampleRpc/Protos/duplicate_check.proto
+++ b/src/Calzolari.Grpc.AspNetCore.Validation.SampleRpc/Protos/duplicate_check.proto
@@ -1,0 +1,22 @@
+syntax = "proto3";
+
+option csharp_namespace = "Calzolari.Grpc.AspNetCore.Validation.SampleRpc";
+
+package Check;
+
+// The hello service definition.
+service DataDuplicationChecker {
+  // Sends a greeting
+  rpc Check (CheckRequest) returns (CheckReply);
+}
+
+// The request message containing the user's name.
+message CheckRequest {
+  string user_name = 1;
+  string email = 2;
+}
+
+// The response message containing the greetings.
+message CheckReply {
+  string message = 1;
+}

--- a/src/Calzolari.Grpc.AspNetCore.Validation.SampleRpc/Services/DataDuplicationCheckerService.cs
+++ b/src/Calzolari.Grpc.AspNetCore.Validation.SampleRpc/Services/DataDuplicationCheckerService.cs
@@ -1,0 +1,52 @@
+﻿using Grpc.Core;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Calzolari.Grpc.AspNetCore.Validation.SampleRpc
+{
+    public class DataDuplicationCheckerService : DataDuplicationChecker.DataDuplicationCheckerBase
+    {
+        private readonly InMemoryDbSimulator _inMemoryDb;
+        private readonly GrpcRequestState _requestState;
+
+        public DataDuplicationCheckerService(InMemoryDbSimulator inMemoryDb, GrpcRequestState requestState)
+        {
+            _inMemoryDb = inMemoryDb;
+            _requestState = requestState;
+        }
+
+
+        public override async Task<CheckReply> Check(CheckRequest request, ServerCallContext context)
+        {
+            if (_inMemoryDb.Users.Any(u => u.UserName == request.UserName))
+                _requestState.AddError(nameof(request.UserName), "The User Name already exists.");
+
+            if (_inMemoryDb.Users.Any(u => u.Email == request.Email))
+                _requestState.AddError(nameof(request.Email), "The Email already exists.");
+
+            await _requestState.ThrowIfNotValidAsync();
+
+            return new CheckReply
+            {
+                Message = $"Hello {request.UserName}, Email: {request.Email}."
+            };
+        }
+    }
+
+    public class InMemoryDbSimulator
+    {
+        public InMemoryDbSimulator(IEnumerable<UserRowSimulator> users)
+        {
+            Users = users.ToList();
+        }
+
+        public List<UserRowSimulator> Users { get; }
+    }
+
+    public class UserRowSimulator
+    {
+        public string UserName { get; set; }
+        public string Email { get; set; }
+    }
+}

--- a/src/Calzolari.Grpc.AspNetCore.Validation.SampleRpc/Startup.cs
+++ b/src/Calzolari.Grpc.AspNetCore.Validation.SampleRpc/Startup.cs
@@ -25,6 +25,7 @@ namespace Calzolari.Grpc.AspNetCore.Validation.SampleRpc
             app.UseEndpoints(endpoints =>
             {
                 endpoints.MapGrpcService<GreeterService>();
+                endpoints.MapGrpcService<DataDuplicationCheckerService>();
 
                 endpoints.MapGet("/",
                     async context =>

--- a/src/Calzolari.Grpc.AspNetCore.Validation.Test/Integration/GrpcRequestStateIntegrationTest.cs
+++ b/src/Calzolari.Grpc.AspNetCore.Validation.Test/Integration/GrpcRequestStateIntegrationTest.cs
@@ -1,0 +1,115 @@
+using Calzolari.Grpc.AspNetCore.Validation.SampleRpc;
+using Grpc.Core;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Calzolari.Grpc.AspNetCore.Validation.Test.Integration
+{
+    public class GrpcRequestStateIntegrationTest : IClassFixture<WebApplicationFactory<Startup>>
+    {
+        public GrpcRequestStateIntegrationTest(WebApplicationFactory<Startup> factory)
+        {
+            _factory = factory
+                .WithWebHostBuilder(builder => builder.ConfigureTestServices(services =>
+                {
+                    services.AddScoped(s =>
+                    {
+                        return new InMemoryDbSimulator(new List<UserRowSimulator>()
+                        {
+                            new UserRowSimulator()
+                            {
+                                UserName = "TestName",
+                                Email = "TestEmail",
+                            }
+                        });
+                    });
+                    services.AddGrpcValidation();
+                }));
+        }
+
+        private readonly WebApplicationFactory<Startup> _factory;
+
+        [Fact]
+        public async Task Should_ResponseMessage_When_UserNameAndEmailAreNotDuplicate()
+        {
+            // Given
+            var client = new DataDuplicationChecker.DataDuplicationCheckerClient(_factory.CreateGrpcChannel());
+
+            // When
+            await client.CheckAsync(new CheckRequest
+            {
+                UserName = "New Name",
+                Email = "New Email"
+            });
+
+            // Then nothing happen.
+        }
+
+        [Fact]
+        public async Task Should_ThrowInvalidArgument_When_NameIsDuplicate()
+        {
+            // Given
+            var client = new DataDuplicationChecker.DataDuplicationCheckerClient(_factory.CreateGrpcChannel());
+
+            // When
+            async Task Action()
+            {
+                await client.CheckAsync(new CheckRequest
+                {
+                    UserName = "TestName",
+                    Email = "New Email"
+                });
+            }
+
+            // Then
+            var rpcException = await Assert.ThrowsAsync<RpcException>(Action);
+            Assert.Equal(StatusCode.InvalidArgument, rpcException.Status.StatusCode);
+        }
+
+        [Fact]
+        public async Task Should_ThrowInvalidArgument_When_EmailIsDuplicate()
+        {
+            // Given
+            var client = new DataDuplicationChecker.DataDuplicationCheckerClient(_factory.CreateGrpcChannel());
+
+            // When
+            async Task Action()
+            {
+                await client.CheckAsync(new CheckRequest
+                {
+                    UserName = "New Name",
+                    Email = "TestEmail"
+                });
+            }
+
+            // Then
+            var rpcException = await Assert.ThrowsAsync<RpcException>(Action);
+            Assert.Equal(StatusCode.InvalidArgument, rpcException.Status.StatusCode);
+        }
+
+        [Fact]
+        public async Task Should_ThrowInvalidArgument_When_BothNameAndEmailAreDuplicate()
+        {
+            // Given
+            var client = new DataDuplicationChecker.DataDuplicationCheckerClient(_factory.CreateGrpcChannel());
+
+            // When
+            async Task Action()
+            {
+                await client.CheckAsync(new CheckRequest
+                {
+                    UserName = "TestName",
+                    Email = "TestEmail"
+                });
+            }
+
+            // Then
+            var rpcException = await Assert.ThrowsAsync<RpcException>(Action);
+            Assert.Equal(StatusCode.InvalidArgument, rpcException.Status.StatusCode);
+        }
+    }
+}

--- a/src/Calzolari.Grpc.AspNetCore.Validation/GrpcRequestState.cs
+++ b/src/Calzolari.Grpc.AspNetCore.Validation/GrpcRequestState.cs
@@ -1,0 +1,69 @@
+﻿using Calzolari.Grpc.AspNetCore.Validation.Internal;
+using FluentValidation.Results;
+using Grpc.Core;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Calzolari.Grpc.AspNetCore.Validation
+{
+    /// <summary>
+    /// Provides the ability to record custom validation errors through the lifecycle of the gRPC request.
+    /// </summary>
+    public class GrpcRequestState
+    {
+        private readonly IValidatorErrorMessageHandler _handler;
+        private readonly List<ValidationFailure> _failures = new List<ValidationFailure>();
+
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GrpcRequestState"/> class.
+        /// </summary>
+        public GrpcRequestState(IValidatorErrorMessageHandler handler)
+        {
+            _handler = handler;
+        }
+
+
+        /// <summary>
+        /// Gets a value that indicates whether the current <see cref="GrpcRequestState"/> instance has errors or not.
+        /// </summary>
+        public bool IsValid => _failures.Count == 0;
+
+
+        /// <summary>
+        /// Adds the specified <paramref name="errorMessage"/> to the <see cref="ValidationFailure.ErrorMessage"/> instance
+        /// that is associated with the specified <paramref name="propertyName"/>.
+        /// </summary>
+        /// <param name="propertyName">The property name of the <see cref="ValidationFailure.PropertyName"/> to add errors to.</param>
+        /// <param name="errorMessage">The error message to add.</param>
+        public void AddError(string propertyName, string errorMessage)
+        {
+            _failures.Add(new ValidationFailure(propertyName, errorMessage));
+        }
+
+
+        /// <summary>
+        /// Throws the <see cref="RpcException"/> associated with the errors recorded using <see cref="AddError(string, string)"/> method, no exception will be thrown if there are no recorded errors.
+        /// </summary>
+        /// <param name="statusCode">The status code to use in the returned <see cref="RpcException"/>.</param>
+        public async Task ThrowIfNotValidAsync(StatusCode statusCode = StatusCode.InvalidArgument)
+        {
+            if (IsValid)
+                return;
+
+            var message = await _handler.HandleAsync(_failures);
+
+            var validationMetadata = _failures.ToValidationMetadata();
+
+            _failures.Clear();
+
+            throw new RpcException(new Status(statusCode, message), validationMetadata);
+        }
+
+
+        /// <summary>
+        /// Removes all failures from this instance of <see cref="GrpcRequestState"/>.
+        /// </summary>
+        public void Clear() => _failures.Clear();
+    }
+}

--- a/src/Calzolari.Grpc.AspNetCore.Validation/ServiceCollectionHelper.cs
+++ b/src/Calzolari.Grpc.AspNetCore.Validation/ServiceCollectionHelper.cs
@@ -16,9 +16,11 @@ namespace Calzolari.Grpc.AspNetCore.Validation
         public static IServiceCollection AddGrpcValidation(this IServiceCollection services)
         {
             services.AddScoped<IValidatorLocator>(provider => new ServiceCollectionValidationProvider(provider));
-            
+
             if (services.All(r => r.ServiceType != typeof(IValidatorErrorMessageHandler)))
                 services.AddSingleton<IValidatorErrorMessageHandler, DefaultErrorMessageHandler>();
+
+            services.AddScoped<GrpcRequestState>();
 
             return services;
         }
@@ -55,7 +57,7 @@ namespace Calzolari.Grpc.AspNetCore.Validation
         /// <param name="validator">configure validation rules</param>
         /// <typeparam name="TMessage">grpc message type</typeparam>
         /// <returns></returns>
-        public static IServiceCollection AddInlineValidator<TMessage>(this IServiceCollection services, 
+        public static IServiceCollection AddInlineValidator<TMessage>(this IServiceCollection services,
             Action<AbstractValidator<TMessage>> validator)
         {
             services.AddSingleton<IValidator<TMessage>>(new Validation.InlineValidator<TMessage>(validator));


### PR DESCRIPTION
#### This PR is based on the idea of _ModelStateDictionary_ class that is commonly used in _ASP.NET CORE Controllers_. 

```csharp
ModelState.AddModelError(key: "", errorMessage: "");
```

#### Usually we need a way to manually add errors in the same form of the validation errors, as example:

1. If the **email** is duplicate in the database, we need to point the error to the **email** property.
1. Adding an error to a property in the business layer or after a database check.


Please note that this PR is more about discussing the idea and not intended to be merged with the main branch, at least for now.