### PR TITLE
enable .net standard version of pacakge

### DIFF
--- a/src/Calzolari.Grpc.Domain/Calzolari.Grpc.Domain.csproj
+++ b/src/Calzolari.Grpc.Domain/Calzolari.Grpc.Domain.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	  <TargetFramework>net8.0</TargetFramework>
     <PackageLicenseFile>license.txt</PackageLicenseFile>
     <Authors>Anthony Giretti</Authors>
     <Company>Calzolari</Company>
@@ -15,6 +14,7 @@
 <PackageIcon>calzolari.png</PackageIcon>
     <PackageIconUrl />
     <FileVersion>8.0.0</FileVersion>
+    <TargetFrameworks>net8.0;netstandard2.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Calzolari.Grpc.Net.Client.Validation/Calzolari.Grpc.Net.Client.Validation.csproj
+++ b/src/Calzolari.Grpc.Net.Client.Validation/Calzolari.Grpc.Net.Client.Validation.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	  <TargetFramework>net8.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Version>8.0.0</Version>
     <Authors>Anthony Giretti</Authors>
@@ -16,6 +15,7 @@
     <PackageIconUrl />
     <AssemblyVersion>8.0.0</AssemblyVersion>
     <FileVersion>8.0.0</FileVersion>
+    <TargetFrameworks>net8.0;netstandard2.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Sometimes client application need to used without aspnet core. We don't need .net8 target here, we can use .netstandard to achive the same